### PR TITLE
Fix venv directory typo in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ The app depends on PyWPS and several other libraries that are listed in
 ``requirements.txt``. It is advisable to run it using a python virtualenv to prevent package instalation problems::
 
     $ virtualenv -p python3 pywps_flask_env
-    $ cd pywps_flask_dir
+    $ cd pywps_flask_env
     $ . bin/activate
     $ git clone https://github.com/geopython/pywps-flask
     $ cd pywps-flask


### PR DESCRIPTION
# Overview
It looks like a simple mistake was made when developing the README. 
The directory name `pywps_flask_env` was accidentally substituted with `pywps_flask_dir`

# Related Issue / Discussion
#63 

# Additional Information

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [ ] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
